### PR TITLE
Permit backups to be made of this applet.

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -41,7 +41,7 @@
         android:largeScreens="true"
         android:anyDensity="true" />
     
-	<application android:name=".MyApplication" android:label="@string/app_name" android:icon="@drawable/icon" android:allowBackup="false">
+	<application android:name=".MyApplication" android:label="@string/app_name" android:icon="@drawable/icon" android:allowBackup="true">
 		<meta-data android:name="android.app.default_searchable" android:value=".TimelineActivity"/>
 
 		<provider android:name=".data.MyProvider"


### PR DESCRIPTION
While doing a 'adb backup' and 'adb restore' dance, I noticed that this applet for some reason disable backups.  This is quite unusual, most apps I had installed permitted that.  If there is no particular reason for this, please consider adding this patch.

Thanks!
