### PR TITLE
Add dark mode support to website

### DIFF
--- a/andstatus.org/www/styles/styles.css
+++ b/andstatus.org/www/styles/styles.css
@@ -1,9 +1,11 @@
+:root {
+	color-scheme: light dark;
+}
+
 html {
     max-width: 900px;
     margin: 0 auto;
     padding: 0;
-    background-color: #fff;
-    color: #000;
     font-family: 'Roboto', sans-serif;
     font-size: 1.2em;
     font-weight: 300;


### PR DESCRIPTION
If the operating system's dark mode is enabled, then switch the website to dark mode. If the operating system's dark mode is disabled (or undefined), then keep the website in light mode.

|Light mode (unchanged)|Dark mode|
|---|---|
|![image](https://github.com/andstatus/andstatus/assets/6900601/edd411bb-8943-42f8-af28-4618acc3d282)|![image](https://github.com/andstatus/andstatus/assets/6900601/e012e811-57c6-4a09-a2ed-2e789b3ba960)|